### PR TITLE
perf: wait for worker initialization on rust side

### DIFF
--- a/__test__/directWorker.mjs
+++ b/__test__/directWorker.mjs
@@ -1,4 +1,4 @@
-import { parentPort, workerData } from 'node:worker_threads'
+import { workerData } from 'node:worker_threads'
 import { registerPlugins } from '../index.js'
 
 const bundlerId = workerData.id
@@ -18,5 +18,3 @@ registerPlugins(bundlerId, [
     }
   }
 ])
-
-parentPort.postMessage('')

--- a/__test__/directWorkerBundler.mjs
+++ b/__test__/directWorkerBundler.mjs
@@ -10,11 +10,11 @@ import { initWorkers } from './initDirectWorker.mjs'
  * }>}
  */
 export const initializeDirect = async (consumeDuration, workerCount) => {
-  const bundlerCreator = new DirectWorkerBundlerCreator()
+  const bundlerCreator = new DirectWorkerBundlerCreator(workerCount)
   const id = bundlerCreator.id
 
-  const stopWorkers = await initWorkers(id, consumeDuration, workerCount)
+  const stopWorkers = initWorkers(id, consumeDuration, workerCount)
 
-  const bundler = bundlerCreator.create()
+  const bundler = await bundlerCreator.create()
   return { bundler, stopWorkers }
 }

--- a/__test__/initDirectWorker.mjs
+++ b/__test__/initDirectWorker.mjs
@@ -4,16 +4,11 @@ import { Worker } from 'node:worker_threads'
  * @param {number} [id]
  * @param {number} [name]
  * @param {number} [duration] in milliseconds
- * @returns {Promise<import('node:worker_threads').Worker>}
+ * @returns {import('node:worker_threads').Worker}
  */
-export const initWorker = async (id, name, duration) => {
+const initWorker = (id, name, duration) => {
   const worker = new Worker(new URL('./directWorker.mjs', import.meta.url), {
     workerData: { id, name, duration }
-  })
-  await new Promise(resolve => {
-    worker.addListener('message', async () => {
-      resolve()
-    })
   })
   return worker
 }
@@ -22,13 +17,13 @@ export const initWorker = async (id, name, duration) => {
  * @param {number} [id]
  * @param {number} [duration] in milliseconds
  * @param {number} [count] number of workers
- * @returns {Promise<() => Promise<void>>}
+ * @returns {() => Promise<void>}
  */
-export const initWorkers = async (id, duration, count) => {
+export const initWorkers = (id, duration, count) => {
   /** @type {Array<import('node:worker_threads').Worker>} */
-  const workers = await Promise.all(Array.from({ length: count }, (_, i) =>
+  const workers = Array.from({ length: count }, (_, i) =>
     initWorker(id, i, duration)
-  ))
+  )
   return async () => {
     await Promise.all(workers.map(worker => worker.terminate()))
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,8 +18,8 @@ export class DirectWorkerBundler {
 }
 export class DirectWorkerBundlerCreator {
   id: number
-  constructor()
-  create(): DirectWorkerBundler
+  constructor(workerCount: number)
+  create(): Promise<DirectWorkerBundler>
 }
 export class SimpleBundler {
   constructor(plugins: Array<Plugin>)

--- a/src/direct_worker_bundler_creator.rs
+++ b/src/direct_worker_bundler_creator.rs
@@ -2,11 +2,11 @@ use std::{
   collections::HashMap,
   sync::{
     atomic::{AtomicU16, Ordering},
-    Mutex,
+    Arc, Mutex,
   },
 };
 
-use napi::{bindgen_prelude::ObjectFinalize, Env, Error, Result};
+use napi::{bindgen_prelude::ObjectFinalize, tokio::sync::Notify, Env, Error, Result};
 
 use crate::{
   direct_worker_bundler::DirectWorkerBundler,
@@ -15,9 +15,21 @@ use crate::{
 
 type PluginsInSingleWorker = Vec<ThreadSafePlugin>;
 
+#[derive(Default)]
+struct PluginsMapValue {
+  plugins_list: Mutex<Vec<PluginsInSingleWorker>>,
+  notify: Notify,
+}
+
+impl PluginsMapValue {
+  fn register(&self, plugins: PluginsInSingleWorker) {
+    self.plugins_list.lock().unwrap().push(plugins);
+    self.notify.notify_one();
+  }
+}
+
 lazy_static! {
-  static ref PLUGINS_MAP: Mutex<HashMap<u16, Mutex<Vec<PluginsInSingleWorker>>>> =
-    Mutex::new(HashMap::new());
+  static ref PLUGINS_MAP: Mutex<HashMap<u16, Arc<PluginsMapValue>>> = Mutex::new(HashMap::new());
   static ref NEXT_ID: AtomicU16 = AtomicU16::new(1);
 }
 
@@ -25,33 +37,54 @@ lazy_static! {
 pub struct DirectWorkerBundlerCreator {
   #[napi(writable = false)]
   pub id: u16,
+  worker_count: u16,
 }
 
 #[napi]
 impl DirectWorkerBundlerCreator {
   #[napi(constructor)]
-  pub fn new() -> napi::Result<Self> {
+  pub fn new(worker_count: u16) -> napi::Result<Self> {
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
 
     let mut map = PLUGINS_MAP.lock().unwrap();
-    map.insert(id, Mutex::new(vec![]));
+    map.insert(id, Arc::new(PluginsMapValue::default()));
 
-    Ok(Self { id })
+    Ok(Self { id, worker_count })
   }
 
   #[napi(writable = false)]
-  pub fn create(&self) -> Result<DirectWorkerBundler> {
+  pub async fn create(&self) -> Result<DirectWorkerBundler> {
+    {
+      let value: Arc<PluginsMapValue>;
+      {
+        let map = PLUGINS_MAP.lock().unwrap();
+        value = map.get(&self.id).unwrap().clone();
+      }
+
+      while value
+        .plugins_list
+        .try_lock()
+        .map_or(true, |plugins| (plugins.len() as u16) < self.worker_count)
+      {
+        value.notify.notified().await;
+      }
+    }
+
     let mut map = PLUGINS_MAP.lock().unwrap();
-    let plugins = map.remove(&self.id);
-    if plugins.is_none() {
+    let value = map.remove(&self.id);
+    if value.is_none() {
       return Err(Error::new(
         napi::Status::GenericFailure,
         "Bundler already created",
       ));
     }
 
-    let plugins = plugins.unwrap().into_inner().unwrap();
-    Ok(DirectWorkerBundler::new(plugins))
+    let plugins_list = Arc::into_inner(value.unwrap())
+      .unwrap()
+      .plugins_list
+      .into_inner()
+      .unwrap();
+    Ok(DirectWorkerBundler::new(plugins_list))
   }
 }
 
@@ -70,6 +103,6 @@ pub fn register_plugins(id: u16, plugins: Vec<Plugin>) {
 
   let mut map = PLUGINS_MAP.lock().unwrap();
   if let Some(existing_plugins) = map.get_mut(&id) {
-    existing_plugins.lock().unwrap().push(plugins);
+    existing_plugins.register(plugins);
   }
 }

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -1,5 +1,9 @@
+use std::fmt::Debug;
+
 use napi::{
-  bindgen_prelude::Promise, threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction}, Either, Env, JsFunction, Result
+  bindgen_prelude::Promise,
+  threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction},
+  Either, Env, JsFunction, Result,
 };
 
 #[napi(object)]
@@ -14,8 +18,19 @@ pub struct ThreadSafePlugin {
   pub resolve_id: Option<ThreadsafeFunction<String>>,
 }
 
+impl Debug for ThreadSafePlugin {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("ThreadSafePlugin")
+      .field("name", &self.name)
+      .finish()
+  }
+}
+
 /// Only pass env when env is main thread
-pub fn convert_plugins_to_thread_safe_plugins(env: Option<&Env>, plugins: Vec<Plugin>) -> Vec<ThreadSafePlugin> {
+pub fn convert_plugins_to_thread_safe_plugins(
+  env: Option<&Env>,
+  plugins: Vec<Plugin>,
+) -> Vec<ThreadSafePlugin> {
   plugins
     .into_iter()
     .map(|p| ThreadSafePlugin {


### PR DESCRIPTION
Creating a PR for reference.

Tried if waiting for worker initialization on rust side reduces the initialization overhead. There was no change in the benchmark. I guess the initialization overhead is coming from the worker initialization itself.
