### PR TITLE
bench: async without cpu consume

### DIFF
--- a/__test__/bench.mjs
+++ b/__test__/bench.mjs
@@ -51,7 +51,7 @@ const params = [
 ]
 
 for (const { consumeDuration, idLengths } of params) {
-  const count = consumeDuration === 0 ? 1000 : Math.floor(1000 / consumeDuration)
+  const count = consumeDuration === 0 ? 100 : Math.floor(100 / consumeDuration)
   for (const idLength of idLengths) {
     await benchGroup(
       `run (consumeDuration: ${consumeDuration}, count: ${count}, idLength: ${idLength})`,

--- a/__test__/directWorker.mjs
+++ b/__test__/directWorker.mjs
@@ -1,5 +1,6 @@
 import { parentPort, workerData } from 'node:worker_threads'
 import { registerPlugins } from '../index.js'
+import { setTimeout } from 'node:timers/promises'
 
 const bundlerId = workerData.id
 const consumeDuration = workerData.duration
@@ -7,11 +8,9 @@ const consumeDuration = workerData.duration
 registerPlugins(bundlerId, [
   {
     name: 'worker',
-    resolveId(_dummy, id) {
+    async resolveId(_dummy, id) {
       if (id.startsWith('worker')) {
-        // eat up the CPU for some time
-        const now = Date.now()
-        while (now + consumeDuration > Date.now()) {}
+        await setTimeout(consumeDuration)
 
         return 'worker:' + id
       }

--- a/__test__/indirectWorker.mjs
+++ b/__test__/indirectWorker.mjs
@@ -1,14 +1,13 @@
 import { parentPort, workerData } from 'node:worker_threads'
+import { setTimeout } from 'node:timers/promises'
 
 const consumeDuration = workerData.duration
 
-parentPort.addListener('message', ({ id, rpcId }) => {
+parentPort.addListener('message', async ({ id, rpcId }) => {
   /** @type {string | undefined} */
   let result
   if (id.startsWith('worker')) {
-    // eat up the CPU for some time
-    const now = Date.now()
-    while (now + consumeDuration > Date.now()) {}
+    await setTimeout(consumeDuration)
 
     result = 'worker:' + id
   }

--- a/__test__/simpleBundler.mjs
+++ b/__test__/simpleBundler.mjs
@@ -1,5 +1,6 @@
 import { SimpleBundler } from '../index.js'
 import { initWorkers } from './initIndirectWorker.mjs'
+import { setTimeout } from 'node:timers/promises'
 
 /**
  * @param {number} consumeDuration
@@ -9,11 +10,9 @@ export const initializeMainThread = (consumeDuration) => {
   const bundler = new SimpleBundler([
     {
       name: 'worker',
-      resolveId(_dummy, id) {
+      async resolveId(_dummy, id) {
         if (id.startsWith('worker')) {
-          // eat up the CPU for some time
-          const now = Date.now()
-          while (now + consumeDuration > Date.now()) {}
+          await setTimeout(consumeDuration)
 
           return 'worker:' + id
         }
@@ -36,7 +35,7 @@ export const initializeIndirect = async (consumeDuration, workerCount) => {
       name: 'worker',
       async resolveId(_dummy, id) {
         if (id.startsWith('worker')) {
-          const r = await call(id);
+          const r = await call(id)
           return r
         }
       }


### PR DESCRIPTION
If the hook doesn't consume cpu time but waits for some time, running in workers has a negative impact. So if the plugin is highly async and doesn't use much CPU time, it's better to run it in the main thread. I don't expect this to happen in bundler case though.

consumeDuration: the time it waits by `setTimeout`
```
run (consumeDuration: 0, count: 100, idLength: 30):
  main: 14.591ms
  indirect (worker count: 1): 1548.575ms
  indirect (worker count: 4): 397.147ms
  indirect (worker count: 8): 204.893ms
  indirect (worker count: 16): 110.355ms
  direct (worker count: 1): 1471.770ms
  direct (worker count: 4): 393.496ms
  direct (worker count: 8): 203.398ms
  direct (worker count: 16): 94.448ms
run (consumeDuration: 1, count: 100, idLength: 30):
  main: 14.984ms
  indirect (worker count: 1): 1565.777ms
  indirect (worker count: 4): 395.550ms
  indirect (worker count: 8): 204.397ms
  indirect (worker count: 16): 110.031ms
  direct (worker count: 1): 1558.500ms
  direct (worker count: 4): 387.574ms
  direct (worker count: 8): 202.619ms
  direct (worker count: 16): 111.052ms
run (consumeDuration: 3, count: 33, idLength: 30):
  main: 15.511ms
  indirect (worker count: 1): 521.539ms
  indirect (worker count: 4): 141.401ms
  indirect (worker count: 8): 79.091ms
  indirect (worker count: 16): 43.666ms
  direct (worker count: 1): 521.287ms
  direct (worker count: 4): 142.809ms
  direct (worker count: 8): 79.505ms
  direct (worker count: 16): 46.999ms
run (consumeDuration: 5, count: 20, idLength: 30):
  main: 15.494ms
  indirect (worker count: 1): 315.986ms
  indirect (worker count: 4): 78.619ms
  indirect (worker count: 8): 47.978ms
  indirect (worker count: 16): 30.890ms
  direct (worker count: 1): 314.411ms
  direct (worker count: 4): 78.235ms
  direct (worker count: 8): 46.582ms
  direct (worker count: 16): 31.947ms
run (consumeDuration: 10, count: 10, idLength: 30):
  main: 16.182ms
  indirect (worker count: 1): 157.673ms
  indirect (worker count: 4): 47.282ms
  indirect (worker count: 8): 31.843ms
  indirect (worker count: 16): 15.888ms
  direct (worker count: 1): 159.227ms
  direct (worker count: 4): 47.220ms
  direct (worker count: 8): 31.444ms
  direct (worker count: 16): 15.776ms
```
